### PR TITLE
docker: remove mono

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ LABEL 	author="Voxel Bone Cloud" maintainer="github@voxelbone.cloud"
 
 RUN 	apt update \
 	&& dpkg --add-architecture i386\
-	&& apt install lib32gcc-s1 libfreetype6 mono-complete -y \
+	&& apt install lib32gcc-s1 libfreetype6 -y \
 	&& useradd -m -d /home/container -s /bin/bash container
 
 USER 	container


### PR DESCRIPTION
Remove mono from main docker image.

With Resonite deprecating the Mono headless, we can remove mono from our Docker image as it is no longer required.