### PR TITLE
docker: Remove .NET 9

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN 	apt update \
 	&& rm /tmp/packages-microsoft-prod.deb \
 	&& dpkg --add-architecture i386 \
 	&& apt update \
-	&& apt install lib32gcc-s1 libfreetype6 dotnet-runtime-9.0 dotnet-runtime-10.0 -y \
+	&& apt install lib32gcc-s1 libfreetype6 dotnet-runtime-10.0 -y \
 	&& rm -r /var/lib/apt/lists/* \
 	&& useradd -m -d /home/container -s /bin/bash container
 


### PR DESCRIPTION
Now that Resonite has updated to use .NET 10, we no longer need .NET 9 installed